### PR TITLE
Test example readme organization change

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,19 +6,16 @@ The project is structured with [whisk](https://github.com/whisk-ml/whisk), an ML
 
 Besides Tensorflow+Keras, the project uses DVC to version control the data download and training stages. As the training stage takes ~20 minutes on a laptop, this can save a significant amount of time when bootstrapping the project.
 
-## Using the trained model
+You can invoke the trained model three different ways:
 
-You can invoke the trained model without checking out the project source code. There are two options:
-
-### Deploy to Heroku as a web service
+## (A) Deploy to Heroku as a web service
 
 Click the button below to deploy the Flask web service to Heroku. See [`app/README.md`](app/README.md) for the HTTP API.
 
 [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/whisk-ml/disaster_tweets)
 
 
-
-### Install the Python Package
+## (B) Install the Python Package
 
 Install this model via pip:
 
@@ -26,7 +23,9 @@ Install this model via pip:
 
 See the [quickstart](#quickstart) section for usage info.
 
-## Prerequisites
+## (C) Check out source code
+
+### Prerequisites
 
 The following is required to run this project:
 
@@ -34,7 +33,7 @@ The following is required to run this project:
 * Python 3.6+
 * A Linux-based OS
 
-## Setup
+### Setup
 
 After cloning this repo and `cd disaster_tweets` run the following in your terminal:
 
@@ -46,9 +45,13 @@ After cloning this repo and `cd disaster_tweets` run the following in your termi
 
 The commands above install whisk, setup the project environment, activate the created venv, setup dvc, and download data stored in DVC.
 
-## Quickstart
+See the [quickstart](#quickstart) section for usage info.
 
-After running setup, invoke the model from the command line:
+## Reference
+
+### Quickstart
+
+After installing pip or running setup, invoke the model from the command line:
 
 ```
 disaster_tweets predict '["Theyd probably still show more life than Arsenal did yesterday, eh? EH?"]'


### PR DESCRIPTION
After listening to Leon's feedback and thinking on this a bit, Im worried the readme is a little confusing when we have the multiple options for use (Heroku, pip-install, cloning).

I gave a quick first-pass at restructuring this. Let me know what you think. We can update the other examples too once we land on the best structure.